### PR TITLE
fix: useEffect check dependencies

### DIFF
--- a/src/enableEffects.js
+++ b/src/enableEffects.js
@@ -18,6 +18,8 @@ const effectInstance = () => {
         return;
       }
 
+      lastDependencies = dependencies;
+      
       cleanupFn();
 
       cleanupFn = fn() || (() => {});


### PR DESCRIPTION
sets the last value of dependencies so we can check if they have changed.
